### PR TITLE
Fix HostGator deployment route and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,25 @@ git push
 Other static hosting platforms such as Netlify or Vercel can be used if you
 prefer. Any service capable of serving the generated `docs/` directory will
 work.
+
+## Deployment to HostGator
+
+If you host your site on HostGator, the repository includes a helper script
+`deploy_hostgator.py` that uploads the frozen site via FTP. Before running the
+script or using the **Deploy to HostGator** button on the admin page, set these
+environment variables:
+
+- `HOSTGATOR_HOST` – the FTP server hostname (e.g. `ftp.example.com`).
+- `HOSTGATOR_USERNAME` – your FTP username.
+- `HOSTGATOR_PASSWORD` – your FTP password.
+- `HOSTGATOR_REMOTE_PATH` – destination directory (defaults to `/public_html`).
+
+With the variables in place you can trigger the deployment from the admin
+interface or run:
+
+```bash
+python deploy_hostgator.py
+```
+
+The script runs `update_site.py` to generate the latest content and then uploads
+the files in `docs/` to your HostGator account.

--- a/app.py
+++ b/app.py
@@ -1031,12 +1031,15 @@ def admin():
     )
 
 
-@app.route("/admin/deploy_hostgator")
+@app.route("/admin/deploy_hostgator", methods=["POST"])
 @require_login
 def deploy_hostgator_route():
     """Generate the static site and upload it to HostGator via FTP."""
-    subprocess.run([sys.executable, "deploy_hostgator.py"], check=True)
-    flash("Site deployed to HostGator.", "success")
+    try:
+        subprocess.run([sys.executable, "deploy_hostgator.py"], check=True)
+        flash("Site deployed to HostGator.", "success")
+    except subprocess.CalledProcessError as e:
+        flash(f"Deployment failed: {e}", "danger")
     return redirect(url_for("admin"))
 
 


### PR DESCRIPTION
## Summary
- allow POST requests for the HostGator deploy endpoint
- show an error message if deployment fails
- document how to deploy the site via FTP in the README

## Testing
- `python -m py_compile app.py deploy_hostgator.py update_site.py daily_post.py update_news.py batch_courses.py freeze.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688bfb796e888333a5b0deee481b62a1