### PR TITLE
Preserve custom page content during deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -592,8 +592,6 @@ def create_tables():
         page = Page.query.filter_by(slug=slug).first()
         if page is None:
             db.session.add(Page(slug=slug, title=slug.capitalize(), content=content))
-        else:
-            page.content = content
     db.session.commit()
     if not get_setting("admin_email") and os.environ.get("ADMIN_EMAIL"):
         set_setting("admin_email", os.environ.get("ADMIN_EMAIL"))


### PR DESCRIPTION
## Summary
- Avoid overwriting existing Page entries in `create_tables`

## Testing
- `python -m py_compile app.py`
- `python freeze.py`


------
https://chatgpt.com/codex/tasks/task_e_68916f4329cc8333a0a7931933fad83d